### PR TITLE
Added state tracking to the timer buttons, fixed bug

### DIFF
--- a/timer/static/js/timer.js
+++ b/timer/static/js/timer.js
@@ -40,89 +40,25 @@ if (longBreakButton.value <= 0) {
 
 function pomodoroModeOn() {
   // In case the timer was running, stop countdownClock function
+  if (currentTimer != 'Pomodoro'){
   clearInterval(countdownClock);
 
   // Reset time and timer display
   countdownMins = pomodoroMinutes;
   countdownSecs = 0;
+  timerState = ''; // clear timer state
+  console.log(timerState);
   resetTimer();
 
   // Set timer to Pomodoro
   currentTimer = "Pomodoro";
+  }
 }
 
 function shortBreakModeOn() {
-
-  // check if Pomodoro mode is on and timer is running
-  if (currentTimer == "Pomodoro" && timeRemaining < (pomodoroMinutes * 60) && timeRemaining != 0) {
-
-    //format prompt message depending if user is logged in or not
-    function checkLoggedIn() {
-      return new Promise(resolve => {
-        $.ajax({
-          url: '/isLoggedIn',
-          success: function (data) {
-            //logged in
-            if (data == 'True') {
-              resolve("Are you sure you want to end your task early? You'll lose 10 points");
-            }
-            //not logged in
-            else {
-              resolve("Are you sure you want to end your task early?");
-            }
-          }
-        });
-      })
-    }
-
-    //show window prompt message
-    async function showMessage() {
-      const message = await checkLoggedIn();
-
-      if (window.confirm(message)) {
-
-        //deduct 10 points from score
-        $.ajax({
-          url: '/deductPoints',
-          success: function (data) {
-            $("#score_span").html(data)
-          }
-        });
-
-        // In case the timer was running, stop countdownClock function
-        clearInterval(countdownClock);
-
-        // Reset time and timer display
-        countdownMins = shortBreakMinutes;
-        countdownSecs = 0;
-        resetTimer();
-
-        // Set timer to Short Break
-        currentTimer = "Short Break";
-      }
-    }
-
-    showMessage();
-
-  }
-  else {
-    // In case the timer was running, stop countdownClock function
-    clearInterval(countdownClock);
-
-    // Reset time and timer display
-    countdownMins = shortBreakMinutes;
-    countdownSecs = 0;
-    resetTimer();
-
-    // Set timer to Short Break
-    currentTimer = "Short Break";
-  }
-}
-
-function longBreakModeOn() {
-  // check if Pomodoro mode is on and timer is running
-  if (currentTimer == "Pomodoro" && timeRemaining < (pomodoroMinutes * 60) && timeRemaining != 0) {
-    
+  if (currentTimer != 'Short Break'){
+    // check if Pomodoro mode is on and timer is running
+    if (currentTimer == "Pomodoro" && timeRemaining < (pomodoroMinutes * 60) && timeRemaining != 0) {
 
       //format prompt message depending if user is logged in or not
       function checkLoggedIn() {
@@ -161,18 +97,94 @@ function longBreakModeOn() {
           clearInterval(countdownClock);
 
           // Reset time and timer display
-          countdownMins = longBreakMinutes;
+          countdownMins = shortBreakMinutes;
           countdownSecs = 0;
+          timerState = ''; // clear timer state
+          console.log(timerState);
           resetTimer();
 
           // Set timer to Short Break
-          currentTimer = "Long Break";
+          currentTimer = "Short Break";
         }
       }
 
       showMessage();
-    
+
+    }
+    else {
+      // In case the timer was running, stop countdownClock function
+      clearInterval(countdownClock);
+
+      // Reset time and timer display
+      countdownMins = shortBreakMinutes;
+      countdownSecs = 0;
+      timerState = ''; // clear timer state
+      console.log(timerState);
+      resetTimer();
+
+      // Set timer to Short Break
+      currentTimer = "Short Break";
+    }
   }
+}
+
+function longBreakModeOn() {
+  if (currentTimer != 'Long Break'){
+    // check if Pomodoro mode is on and timer is running
+    if (currentTimer == "Pomodoro" && timeRemaining < (pomodoroMinutes * 60) && timeRemaining != 0) {
+      
+
+        //format prompt message depending if user is logged in or not
+        function checkLoggedIn() {
+          return new Promise(resolve => {
+            $.ajax({
+              url: '/isLoggedIn',
+              success: function (data) {
+                //logged in
+                if (data == 'True') {
+                  resolve("Are you sure you want to end your task early? You'll lose 10 points");
+                }
+                //not logged in
+                else {
+                  resolve("Are you sure you want to end your task early?");
+                }
+              }
+            });
+          })
+        }
+
+        //show window prompt message
+        async function showMessage() {
+          const message = await checkLoggedIn();
+
+          if (window.confirm(message)) {
+
+            //deduct 10 points from score
+            $.ajax({
+              url: '/deductPoints',
+              success: function (data) {
+                $("#score_span").html(data)
+              }
+            });
+
+            // In case the timer was running, stop countdownClock function
+            clearInterval(countdownClock);
+
+            // Reset time and timer display
+            countdownMins = longBreakMinutes;
+            countdownSecs = 0;
+            timerState = ''; // clear timer state
+            console.log(timerState);
+            resetTimer();
+
+            // Set timer to Short Break
+            currentTimer = "Long Break";
+          }
+        }
+
+        showMessage();
+      
+    }
     else {
       // In case the timer was running, stop countdownClock function
       clearInterval(countdownClock);
@@ -180,12 +192,15 @@ function longBreakModeOn() {
       // Reset time and timer display
       countdownMins = longBreakMinutes;
       countdownSecs = 0;
+      timerState = ''; // clear timer state
+      console.log(timerState);
       resetTimer();
 
       // Set timer to Short Break
       currentTimer = "Long Break";
     }
   }
+}
 
 function startTimer() {
   console.log(timerState);

--- a/timer/static/js/timer.js
+++ b/timer/static/js/timer.js
@@ -260,7 +260,7 @@ function padValue(integerValue) {
 function countdownTimer() {
   timeRemaining--;
   displayTimer();
-  console.log(timerState)
+  //console.log(timerState)
   // If time is up, stop the timer and display notification
   if (timeRemaining == 0 && currentTimer == "Pomodoro") {
 

--- a/timer/views.py
+++ b/timer/views.py
@@ -29,9 +29,17 @@ def index_view(request):
     if request.user.is_authenticated:
         if 'taskName' not in request.session:  # Takes advantage of user sessions, checks to see if the taskName is in their session
             now = datetime.now()
+            request.session['defaultTaskName'] = True
+            request.session['taskNumber'] = 1
             request.session['taskName'] = 'Task: ' + now.strftime(
-                "%Y-%m-%d_%H:%M:%S")  # creates a default taskName if they dont have one
-            
+                "%Y-%m-%d: #1")  # creates a default taskName if they dont have one
+        # elif request.session['defaultTaskName']:
+        #     now = datetime.now()
+        #     request.session['taskNumber'] += 1
+        #     request.session['taskName'] = 'Task: ' + now.strftime(
+        #         "%Y-%m-%d: #" + str(request.session['taskNumber']))  # creates a default taskName if they dont have one
+
+
         if 'userSessionName' not in request.session:  # Takes advantage of user sessions, checks to see if the userSessionName is in their session
             now = datetime.now()
             request.session['userSessionName'] = 'Session: ' + now.strftime(
@@ -58,6 +66,7 @@ def editTask_view(request):
         if form.is_valid():                      # checks if the new name is valid
             taskName = form.cleaned_data['taskName']   # if its valid, get the task and add it to the list of tasks
             request.session['taskName'] = taskName             # changing the taskName for the user session
+            request.session['defaultTaskName'] = False
             return HttpResponseRedirect(
                 reverse('index'))  # returns the user to the timer, is not hard coded, uses the index name and reverses
         else:                                       # if not, it sends them back to the for with their invalid input


### PR DESCRIPTION
I added state tracking to the timer (var timerState) and now in order for the 'start', 'pause', and 'reset' buttons to do anything the timer must be in the proper corresponding state. This fixed a bug where clicking the 'start' button multiple times would cause the timer to go faster and faster. We will also need this to know and maintain the proper state of the timer in order to create and manage tasks. Also changed the 'Pomodoro', 'Short Break', and 'Long Break' buttons to only work if the current timer was different from the timer the button represents. These also now clear timerState before calling restTimer()

For the startTimer() function to work the state of the timer must be STOPPED or PAUSED
For the pauseTimer() function to work, the state of the timer must be STARTED
For the resetTImer() function to work, the state of the timer cant be STOPPED

The default value of the state is blank. It is immediately changed to STOPPED on page load when the resetTimer() function is called. This changes the state to STOPPED and sets the proper number of minutes in the timer.

Also made a minor change to how the task names are displayed and created a session variable to track the task number.