### PR TITLE
Edit/update task category in db when new category selected from drop down

### DIFF
--- a/pomodoro/urls.py
+++ b/pomodoro/urls.py
@@ -19,7 +19,7 @@ from django.contrib.auth import views as auth_views
 
 from accounts.views import create_account_view, profile_view, change_default_times_view, upgrade
 from timer.views import index_view, editTask_view, add_points, deduct_points, is_logged_in, editUserSession_view, \
-    save_task_info
+    save_task_info, update_task_category
 
 urlpatterns = [
     path('', index_view, name='index'),
@@ -36,5 +36,6 @@ urlpatterns = [
     path('deductPoints/', deduct_points, name="deductPoints"),
     path('isLoggedIn/', is_logged_in, name="isLoggedIn"),
     path('saveTaskData/', save_task_info, name="saveTaskData"),
+    path('updateTaskCategory/', update_task_category, name="updateTaskCategory"),
     path('upgrade/', upgrade, name='upgrade'),
 ]

--- a/timer/static/js/timer.js
+++ b/timer/static/js/timer.js
@@ -2,6 +2,7 @@ document.addEventListener("DOMContentLoaded", pomodoroModeOn);
 document.getElementById("startButton").addEventListener("click", startTimer);
 document.getElementById("pauseButton").addEventListener("click", pauseTimer);
 document.getElementById("resetButton").addEventListener("click", resetTimer);
+document.getElementById("taskCategory").addEventListener("change", updateCategory);
 
 var pomodoroButton = document.getElementById("pomodoroModeButton");
 pomodoroButton.addEventListener("click", pomodoroModeOn);
@@ -387,5 +388,25 @@ function countdownTimer() {
     pauseTimer();
     timerState == 'STOPPED'
     console.log(timerState)
+  }
+}
+
+// update the task category in the db
+function updateCategory() {
+  console.log('updateCategory() called...')
+  // save task category to db only if a promodoro task 
+  if(currentTimer == "Pomodoro"){
+    let currentCategory = document.getElementById('taskCategory').value;
+    $.ajax({
+      url: '/updateTaskCategory/',
+      method: 'post',
+      dataType: 'json',
+      data: JSON.stringify({
+          'category' : currentCategory,
+        }),
+      success: function(data) {
+        console.log(data);
+      }
+    });
   }
 }

--- a/timer/views.py
+++ b/timer/views.py
@@ -155,30 +155,14 @@ def save_task_info(request):
 @csrf_exempt
 def update_task_category(request):
     if request.user.is_authenticated:
-        # get the current task id from the django session
-        # currTaskId = request.session['taskId']
-
         # create instance of current task by using its id stored in the the django session
         currentTask = Task.objects.get(id = request.session['taskId'])
-
         # pull current category from ajax call
         category = json.loads(request.body)['category']
         # update the current task category
         currentTask.category = category
-
         # update/save the changed category to the database
         currentTask.save()
-
-        # ##### old ### pull data from ajax call
-        # task_name = json.loads(request.body)['task_name']
-        # task_time = json.loads(request.body)['task_time']
-        # category = json.loads(request.body)['category']
-        # # create instance of current session to use as FK for Task db
-        # session_id = UserSession.objects.get(id = request.session['userSessionId'])
-
-        # create new entry in Task db
-        #newTask = Task.objects.create(usersession=session_id, task_name=task_name, task_time=task_time, time_start=timezone.now(), category=category)
-        #request.session['taskId'] = newTask.pk
         return HttpResponse(status=200)
     else:
         errMessage = 'Error: user not logged in.'

--- a/timer/views.py
+++ b/timer/views.py
@@ -144,11 +144,45 @@ def save_task_info(request):
 
         # create new entry in Task db
         newTask = Task.objects.create(usersession=session_id, task_name=task_name, task_time=task_time, time_start=timezone.now(), category=category)
+        request.session['taskId'] = newTask.id  # save the id for the task in the database to the session as taskId
         return HttpResponse(status=200)
     else:
         errMessage = 'Error: user not logged in.'
         print(errMessage)
         return HttpResponse(errMessage)
+        
+# Update task category in the db when task category is changed
+@csrf_exempt
+def update_task_category(request):
+    if request.user.is_authenticated:
+        # get the current task id from the django session
+        # currTaskId = request.session['taskId']
 
+        # create instance of current task by using its id stored in the the django session
+        currentTask = Task.objects.get(id = request.session['taskId'])
+
+        # pull current category from ajax call
+        category = json.loads(request.body)['category']
+        # update the current task category
+        currentTask.category = category
+
+        # update/save the changed category to the database
+        currentTask.save()
+
+        # ##### old ### pull data from ajax call
+        # task_name = json.loads(request.body)['task_name']
+        # task_time = json.loads(request.body)['task_time']
+        # category = json.loads(request.body)['category']
+        # # create instance of current session to use as FK for Task db
+        # session_id = UserSession.objects.get(id = request.session['userSessionId'])
+
+        # create new entry in Task db
+        #newTask = Task.objects.create(usersession=session_id, task_name=task_name, task_time=task_time, time_start=timezone.now(), category=category)
+        #request.session['taskId'] = newTask.pk
+        return HttpResponse(status=200)
+    else:
+        errMessage = 'Error: user not logged in.'
+        print(errMessage)
+        return HttpResponse(errMessage)
 
 


### PR DESCRIPTION
Now when you change the task category on the select drop down it will be saved to the database for the current task.  

It does this by retrieving the task id from the database when the task is initially created in the django session as request.session['taskId'].  There is now an event listener on the select drop down that calls a javascript function called updateCagtegory on change.  This function does an ajax post to  /updateTaskCategory/.  This calls a new function in timer/views.py that uses the request.session['taskId'] to retrieve the task from the database by id, update its category, then save it back to the db with the new category.