### PR TITLE
Fixed bug for non-logged in user

### DIFF
--- a/timer/static/js/timer.js
+++ b/timer/static/js/timer.js
@@ -240,10 +240,10 @@ function startTimer() {
   
   console.log(timerState);
   // Check to see if the timer has already been completed and reset if it has
-  if (timeRemaining == 0) {
+  if (timeRemaining === 0) {
     resetTimer();
   }
-  if (timerState == 'STOPPED' || timerState == 'PAUSED'){
+  if (timerState === 'STOPPED' || timerState === 'PAUSED'){
     timerState = 'STARTED';
     console.log(timerState)
     // Call countdownTimer function every second (1000ms)
@@ -251,24 +251,24 @@ function startTimer() {
   } 
 
   // save task data to db if task is started fresh only
-  if(timeRemaining == pomodoroMinutes * 60){
-    let currentCategory = document.getElementById('taskCategory').value;
-    $.ajax({
-      url: '/saveTaskData/',
-      method: 'post',
-      dataType: 'json',
-      data: JSON.stringify({
+  if(timeRemaining === pomodoroMinutes * 60){
+    if (document.getElementById("taskCategory") != null) {
+      let currentCategory = document.getElementById('taskCategory').value;
+      $.ajax({
+        url: '/saveTaskData/',
+        method: 'post',
+        dataType: 'json',
+        data: JSON.stringify({
           'task_name': $('#taskName').text(),
-          'task_time' : pomodoroMinutes,
-          'category' : currentCategory,
+          'task_time': pomodoroMinutes,
+          'category': currentCategory,
         }),
-      success: function(data) {
-        console.log(data);
-      }
-    });
-
+        success: function (data) {
+          console.log(data);
+        }
+      });
+    }
   }
-
 }
 
 function pauseTimer() {

--- a/timer/static/js/timer.js
+++ b/timer/static/js/timer.js
@@ -2,7 +2,9 @@ document.addEventListener("DOMContentLoaded", pomodoroModeOn);
 document.getElementById("startButton").addEventListener("click", startTimer);
 document.getElementById("pauseButton").addEventListener("click", pauseTimer);
 document.getElementById("resetButton").addEventListener("click", resetTimer);
-document.getElementById("taskCategory").addEventListener("change", updateCategory);
+if (document.getElementById("taskCategory") != null){
+  document.getElementById("taskCategory").addEventListener("change", updateCategory);
+}
 
 var pomodoroButton = document.getElementById("pomodoroModeButton");
 pomodoroButton.addEventListener("click", pomodoroModeOn);
@@ -381,12 +383,12 @@ function countdownTimer() {
     }
 
     showMessage();
-    timerState == 'STOPPED'
+    timerState = ''
     console.log(timerState)
   }
   else if (timeRemaining == 0) {
     pauseTimer();
-    timerState == 'STOPPED'
+    timerState = ''
     console.log(timerState)
   }
 }
@@ -395,7 +397,7 @@ function countdownTimer() {
 function updateCategory() {
   console.log('updateCategory() called...')
   // save task category to db only if a promodoro task 
-  if(currentTimer == "Pomodoro"){
+  if(currentTimer == "Pomodoro" && timerState != 'STOPPED' && timerState != ''){
     let currentCategory = document.getElementById('taskCategory').value;
     $.ajax({
       url: '/updateTaskCategory/',


### PR DESCRIPTION
If a user is not logged in, the addEventListener was throwing an error since the category field doesn't exist if the user is not logged in. 

Fixed a bug so that when a user first logs in and changes the category that it doesn't throw an internal error to the terminal, and that once a task is finished that a user will not be able to further update the category for task.  The user can pre-select a category for the next task that will automatically save to the database when the Start button is clicked and then the task can be modified while the timer is running, or paused until that task has been finished.