### PR TITLE
Save and update task time_end to db

### DIFF
--- a/pomodoro/urls.py
+++ b/pomodoro/urls.py
@@ -20,7 +20,7 @@ from django.contrib.auth import views as auth_views
 from usersessions.views import tasks_view, sessions_view
 from accounts.views import create_account_view, profile_view, change_default_times_view, upgrade
 from timer.views import index_view, editTask_view, add_points, deduct_points, is_logged_in, editUserSession_view, \
-    save_task_info, editSessionDescription_view, update_task_category
+    save_task_info, editSessionDescription_view, update_task_category, update_task_time_end
 
 
 urlpatterns = [
@@ -43,4 +43,5 @@ urlpatterns = [
     path('saveTaskData/', save_task_info, name="saveTaskData"),
     path('updateTaskCategory/', update_task_category, name="updateTaskCategory"),
     path('upgrade/', upgrade, name='upgrade'),
+    path('updateTaskTimeEnd/', update_task_time_end, name='updateTaskTimeEnd'),
 ]

--- a/timer/static/js/timer.js
+++ b/timer/static/js/timer.js
@@ -270,17 +270,18 @@ function startTimer() {
 }
 
 function pauseTimer() {
-  
-  
-
+  // update the task end time in db if user is logged in
+  if (checkLoggedInBool()){
+    updateTimeEnd();
+  };
   if (timerState == 'STARTED') {
     document.getElementById("pauseButton").classList.add("control-button-selected");
     document.getElementById("startButton").classList.remove("control-button-selected");
     console.log(timerState);
-  // Stop countdownClock function
-  clearInterval(countdownClock);
-  timerState = 'PAUSED';
-  console.log(timerState);
+    // Stop countdownClock function
+    clearInterval(countdownClock);
+    timerState = 'PAUSED';
+    console.log(timerState);
   } 
 }
 
@@ -409,4 +410,37 @@ function updateCategory() {
       }
     });
   }
+}
+
+// update the task time_end in the db
+function updateTimeEnd(){
+  console.log('updateTimeEndy() called...')
+    // save task task to db only if a promodoro task 
+    if(currentTimer == "Pomodoro"){
+      $.ajax({
+        url: '/updateTaskTimeEnd',
+        success: function(data) {
+          console.log('Updated Task time_end', data);
+        }
+      });
+    }
+}
+// checks if a user is logged in and returns true/false
+function checkLoggedInBool() {
+  return new Promise(resolve => {
+    $.ajax({
+      url: '/isLoggedIn',
+      success: function (data) {
+        console.log(data);
+        //logged in
+        if (data == 'True') {
+          return true;
+        }
+        //not logged in
+        else {
+          return false;
+        }
+      }
+    });
+  })
 }

--- a/timer/static/js/timer.js
+++ b/timer/static/js/timer.js
@@ -416,7 +416,7 @@ function updateCategory() {
 function updateTimeEnd(){
   console.log('updateTimeEndy() called...')
     // save task task to db only if a promodoro task 
-    if(currentTimer == "Pomodoro"){
+    if(currentTimer == "Pomodoro" && timerState != 'STOPPED' && timerState != ''){
       $.ajax({
         url: '/updateTaskTimeEnd',
         success: function(data) {

--- a/timer/views.py
+++ b/timer/views.py
@@ -213,4 +213,15 @@ def update_task_category(request):
         print(errMessage)
         return HttpResponse(errMessage)
 
-
+# AJAX for updating task time_end in db
+def update_task_time_end(request):
+    if request.user.is_authenticated:
+        # create instance of current task by using its id stored in the the django session
+        currentTask = Task.objects.get(id = request.session['taskId'])
+        currentTask.time_end = timezone.now()
+        currentTask.save()
+        return HttpResponse(status=200)
+    else:
+        errMessage = 'Error: user not logged in.'
+        print(errMessage)
+        return HttpResponse(errMessage)


### PR DESCRIPTION
Created a JS function called updateTimeEnd() that does an ajax call to new view function called update-task_time_end that will create/update the time_end for a task in the database. This is called from the pauseTimer() function for logged in users and only runs if its a pomodoro.  This should make it update the end time any time the clock stops for whatever reason including being paused by the user, reset by the user, switching to a rest, or the clock reaching 0. 

If the clock is paused then resumed, the time_end will be updated again with the end time when the clock reaches 0 (or it is paused/stopped again)