### PR TITLE
Display data in a table on timer page

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -57,6 +57,11 @@ a.btn-submit:hover, button.btn-submit:hover{
   width: 500px; 
 }
 
+.timerTableDiv {
+  max-width:210px; 
+  overflow-wrap:break-word;
+}
+
 /* task and control buttons on home page */
 #pomodoroModeButton, #shortBreakModeButton, #longBreakModeButton,
 #startButton, #pauseButton, #resetButton {

--- a/static/styles.css
+++ b/static/styles.css
@@ -28,8 +28,33 @@ body {
   border-color: black;
 }
 
-a.btn-submit:hover, button.btn-submit:hover {
+a.btn-submit:hover, button.btn-submit:hover{
   color: white;
+}
+
+.btn-outline-success:hover {
+  color: white;
+}
+
+.editbtn {
+  color: #28a745;
+  border: solid #28a745;
+  padding: 4px 8px;
+  font-size: 14px;
+  line-height: normal;
+  border-radius: 4.8px;
+  border-width: thin;
+}
+
+.editbtn:hover {
+  color: white;
+  background-color: rgba(41, 168, 71, 0.431);
+  text-decoration: none;
+}
+
+/* Table styling on timer page */
+.timerInformation {
+  width: 500px; 
 }
 
 /* task and control buttons on home page */
@@ -162,11 +187,11 @@ i:hover{
 
 /* edit icon */
 .fa-edit {
-  color:rgb(228, 55, 55);
+  color:tomato;
 }
 
-.fa-edit:hover {
-  color:rgb(172, 36, 36);
+.disable{
+  pointer-events:none;
 }
 
 /* modal */

--- a/timer/templates/index.html
+++ b/timer/templates/index.html
@@ -43,23 +43,26 @@
                         <button type="button" id="resetButton">Reset</button>
                     </div>
                     <br>
-                
-                    
-                    <div>
-                        {% if user.username %}
-                        Session: <span id="userSessionName">{{ userSessionName }} </span><a href="{% url 'editUserSession' %}"><i class="fas fa-edit"></i></a>
-                        {% endif %}
-                    </div>
-                    <div>
-                        {% if user.username %}
-                        Task: <span id="taskName">{{ taskName }}</span> <a href="{% url 'editTask' %}"><i class="fas fa-edit"></i></a>
-                        {% endif %}
-                    </div>
-                    <div>
-                        {% if user.username %}
-                        Task Category: 
-                        <select name="taskCategory" id="taskCategory">
-
+                    <br>
+                    {% if user.username %}
+                    <table class="table timerInformation">
+                      <tr>
+                        <td><strong>Session:</strong></td> 
+                        <td><div id="userSessionName">{{ userSessionName }} </div></td>
+                        <td><a role="button" class="editbtn" href="{% url 'editUserSession' %}">
+                          <i class="fas fa-edit disable"></i> <strong>Edit</strong></a>
+                        </td> 
+                      </tr>
+                      <tr>
+                        <td><strong>Task:</strong></td>
+                        <td><div id="taskName">{{ taskName }}</div></td>
+                        <td> <a role="button" class="editbtn" href="{% url 'editTask' %}">
+                          <i class="fas fa-edit disable"></i> <strong>Edit</strong></a>
+                        </td>
+                      </tr>
+                      <tr>
+                        <td><strong>Task Category:</strong></td> 
+                        <td><select name="taskCategory" id="taskCategory">
                             {% for category in task_categories %}
                             <option value="{{ category}}">{{ category}}</option>
                             {% empty %}
@@ -69,18 +72,31 @@
                             <option value="Work">Work</option>
                             <option value="Reading">Reading</option>
                             {% endfor %}
-                        </select>
-                        <a {% if request.resolver_match.url_name == "manageCategories" %}active{% endif %}" href="{% url 'manageCategories' %}"><i class="fas fa-edit"></i></a>
+                          </select>
+                        </td>
+                        <td><a role="button" class="editbtn" 
+                            {% if request.resolver_match.url_name == "manageCategories" %}active{% endif %}" href="{% url 'manageCategories' %}">
+                            <i class="fas fa-edit disable"></i> <strong>Edit</strong></a>
+
+                      </tr>
+                      <tr>
+                        <td><strong>Session Description:</strong></td>
+                        <td> 
+                        {% if description %}
+                         <div style="max-width:200px; overflow-wrap:break-word;" id="userSessionDescription">{{ description }} </div> 
                         {% endif %}
-                    </div>
-                    <div id="userSessionDescription">
-                        {% if user.username %}
-                            Session Description: <a href="{% url 'editSessionDescription' %}"><i class="fas fa-edit"></i></a> <br>
-                            {% if description %}
-                                <textarea class="form-control" style="height:100%;" readonly id="description" >{{ description }}</textarea> 
-                            {% endif %}
-                        {% endif %}
-                    </div>
+                        </td>
+                        <td><a role="button" class="editbtn" href="{% url 'editSessionDescription' %}">
+                          <i class="fas fa-edit disable"></i> <strong>Edit</strong></a>
+                        </td>
+                      </tr>
+                      <tr display="hidden">
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                      </tr>
+                    </table>
+                    {% endif %}
                 </div>               
             </div>
             

--- a/timer/templates/index.html
+++ b/timer/templates/index.html
@@ -47,14 +47,14 @@
                     {% if user.username %}
                     <table class="table timerInformation">
                       <tr>
-                        <td><strong>Session:</strong></td> 
+                        <td><strong>Session Name:</strong></td> 
                         <td><div class="timerTableDiv" id="userSessionName">{{ userSessionName }} </div></td>
                         <td><a role="button" class="editbtn" href="{% url 'editUserSession' %}">
                           <i class="fas fa-edit disable"></i> <strong>Edit</strong></a>
                         </td> 
                       </tr>
                       <tr>
-                        <td><strong>Task:</strong></td>
+                        <td><strong>Task Name:</strong></td>
                         <td><div class="timerTableDiv" id="taskName">{{ taskName }}</div></td>
                         <td> <a role="button" class="editbtn" href="{% url 'editTask' %}">
                           <i class="fas fa-edit disable"></i> <strong>Edit</strong></a>

--- a/timer/templates/index.html
+++ b/timer/templates/index.html
@@ -48,14 +48,14 @@
                     <table class="table timerInformation">
                       <tr>
                         <td><strong>Session:</strong></td> 
-                        <td><div id="userSessionName">{{ userSessionName }} </div></td>
+                        <td><div class="timerTableDiv" id="userSessionName">{{ userSessionName }} </div></td>
                         <td><a role="button" class="editbtn" href="{% url 'editUserSession' %}">
                           <i class="fas fa-edit disable"></i> <strong>Edit</strong></a>
                         </td> 
                       </tr>
                       <tr>
                         <td><strong>Task:</strong></td>
-                        <td><div id="taskName">{{ taskName }}</div></td>
+                        <td><div class="timerTableDiv" id="taskName">{{ taskName }}</div></td>
                         <td> <a role="button" class="editbtn" href="{% url 'editTask' %}">
                           <i class="fas fa-edit disable"></i> <strong>Edit</strong></a>
                         </td>
@@ -83,7 +83,7 @@
                         <td><strong>Session Description:</strong></td>
                         <td> 
                         {% if description %}
-                         <div style="max-width:200px; overflow-wrap:break-word;" id="userSessionDescription">{{ description }} </div> 
+                         <div class="timerTableDiv" id="userSessionDescription">{{ description }} </div> 
                         {% endif %}
                         </td>
                         <td><a role="button" class="editbtn" href="{% url 'editSessionDescription' %}">


### PR DESCRIPTION
Based on user feedback, I have updated the timer page so that the information is displayed in a table.  

- Session, Task, Task Category, and Session Description labels are bold to distinguish between the label and data.
- Removed the text box on the Session Description that made it appear that it was editable when it was not.
- The edit buttons align nicely in the rows, which should make it easier for the user to know which attribute they're updating (as well as updated the naming for Tasks/Sessions to indicate it's the name for those items)
- Overall the items are aligned nicely to aid in readability