### PR TITLE
Task category drop down menu updated

### DIFF
--- a/timer/templates/index.html
+++ b/timer/templates/index.html
@@ -70,7 +70,9 @@
                           <option value="Reading">Reading</option>
                           {% for category in task_categories %}
                             {% if category not in "General,Homework,Studying,Work,Reading" %}
-                              <option value="{{ category}}">{{ category}}</option>
+                              {% if category not in "general,homework,studying,work,reading" %}
+                                <option value="{{ category}}">{{ category}}</option>
+                              {% endif %}
                             {% endif %}
                           {% endfor %}
                           </select>

--- a/timer/templates/index.html
+++ b/timer/templates/index.html
@@ -63,15 +63,16 @@
                       <tr>
                         <td><strong>Task Category:</strong></td> 
                         <td><select name="taskCategory" id="taskCategory">
-                            {% for category in task_categories %}
-                            <option value="{{ category}}">{{ category}}</option>
-                            {% empty %}
-                            <option value="General">General</option>
-                            <option value="Homework">Homework</option>
-                            <option value="Studying">Studying</option>
-                            <option value="Work">Work</option>
-                            <option value="Reading">Reading</option>
-                            {% endfor %}
+                          <option value="General">General</option>
+                          <option value="Homework">Homework</option>
+                          <option value="Studying">Studying</option>
+                          <option value="Work">Work</option>
+                          <option value="Reading">Reading</option>
+                          {% for category in task_categories %}
+                            {% if category not in "General,Homework,Studying,Work,Reading" %}
+                              <option value="{{ category}}">{{ category}}</option>
+                            {% endif %}
+                          {% endfor %}
                           </select>
                         </td>
                         <td><a role="button" class="editbtn" 


### PR DESCRIPTION
Updated the task category drop down list so that the default categories will display in addition to the custom user ones 
-- Order is default task categories and then the custom user ones at the end
-- If a user creates a category with the same name as a default category, it will not display (in this case, it is not case sensitive -- i.e. Reading and reading -- both will be filtered out)
-- Doesn't prevent the case when a user mis-spells a word, however.  raeding would be considered a valid category name different from reading.