### PR TITLE
fixed crash bug when current session deleted

### DIFF
--- a/timer/views.py
+++ b/timer/views.py
@@ -41,9 +41,15 @@ def index_view(request):
 
     # If logged in, check if the user has an active session. 
     user_session_description = ''
+
     if 'userSessionId' in request.session:  # If active session, get the current description
-        userSessionId = request.session['userSessionId']
-        user_session_description = UserSession.objects.get(id=userSessionId).description
+        try:
+            userSessionId = request.session['userSessionId']
+            user_session_description = UserSession.objects.get(id=userSessionId).description
+        except UserSession.DoesNotExist:
+            print("No Session Exists")
+            del request.session['userSessionId']
+            del request.session['userSessionName']
 
     # Set defaults if missing current objects
     set_task_default_if_missing(request)
@@ -62,17 +68,16 @@ def index_view(request):
 # Checks if the request session has a taskname, if not populates the defaults for the session
 def set_task_default_if_missing(request):
     if 'taskName' not in request.session:  # Takes advantage of user sessions, checks to see if the taskName is in their session
-        now = timezone.now()
         request.session['defaultTaskName'] = True
-        request.session['taskNumber'] = 1
-        request.session['taskName'] = 'Task: ' + now.strftime("%Y-%m-%d: #1")  # creates a default taskName if they dont have one
+        request.session['taskName'] = 'Default Task' 
 
 
 # Checks if the request session has a user session name, if not populates the defaults for the session
 def set_user_session_default_if_missing(request):
     if 'userSessionName' not in request.session:  # Takes advantage of user sessions, checks to see if the userSessionName is in their session
+        print("Making new user session")
         now = timezone.now()
-        request.session['userSessionName'] = 'Session: ' + now.strftime("%Y-%m-%d_%H:%M:%S")  # creates a default userSessionName if they dont have one
+        request.session['userSessionName'] = 'Default Session'
         userSessionObject = UserSession.objects.create(user= request.user, session_time_start = now, session_name=request.session['userSessionName'])
         request.session['userSessionId'] = userSessionObject.id
 


### PR DESCRIPTION
Used a try/except to fix the bug. Now if the UserSession.objects.get(id=userSessionId) query comes back with DoesNotExist (what was causing the error) it will remove the session name and id from the django user session and then the functionset_user_session_default_if_missing() will create a new one.

I also cleaned up the default session name and task name as they looked ugly. 